### PR TITLE
Update links to point to PyCQA after migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Status
 
-[![Build Status](https://travis-ci.org/landscapeio/pylint-plugin-utils.svg?branch=master)](https://travis-ci.org/landscapeio/pylint-plugin-utils)
-[![Code Health](https://landscape.io/github/landscapeio/pylint-plugin-utils/master/landscape.svg?style=flat)](https://landscape.io/github/landscapeio/pylint-plugin-utils/master)
-[![Coverage Status](https://coveralls.io/repos/github/landscapeio/pylint-plugin-utils/badge.svg?branch=master)](https://coveralls.io/github/landscapeio/pylint-plugin-utils?branch=master)
+[![Build Status](https://travis-ci.org/PyCQA/pylint-plugin-utils.svg?branch=master)](https://travis-ci.org/PyCQA/pylint-plugin-utils)
+[![Code Health](https://landscape.io/github/PyCQA/pylint-plugin-utils/master/landscape.svg?style=flat)](https://landscape.io/github/PyCQA/pylint-plugin-utils/master)
+[![Coverage Status](https://coveralls.io/repos/github/PyCQA/pylint-plugin-utils/badge.svg?branch=master)](https://coveralls.io/github/PyCQA/pylint-plugin-utils?branch=master)
 
 # About
 
-Utilities and helpers for writing Pylint plugins. This is not a direct Pylint plugin, but rather a set of tools and functions used by other plugins such as [pylint-django](https://github.com/landscapeio/pylint-django) and [pylint-celery](https://github.com/landscapeio/pylint-celery).
+Utilities and helpers for writing Pylint plugins. This is not a direct Pylint plugin, but rather a set of tools and functions used by other plugins such as [pylint-django](https://github.com/PyCQA/pylint-django) and [pylint-celery](https://github.com/PyCQA/pylint-celery).
 
 # License
 


### PR DESCRIPTION
I was updating the README with the new url to point to PyCQA but it seems some elements like landscape.io and coveralls have not been migrated yet. Is that expected?