### PR TITLE
Import exception from pylint.exceptions instead of utils

### DIFF
--- a/pylint_plugin_utils/__init__.py
+++ b/pylint_plugin_utils/__init__.py
@@ -1,8 +1,6 @@
 import sys
-try:
-    from pylint.exceptions import UnknownMessageError as UnknownMessage
-except ImportError:
-    from pylint.exceptions import UnknownMessage
+
+from pylint.exceptions import UnknownMessageError
 
 
 def get_class(module_name, kls):
@@ -137,7 +135,7 @@ def suppress_message(linter, checker_method, message_id_or_symbol, test_func):
                    for pylint_message in pylint_messages
                    for symbol in (pylint_message.msgid, pylint_message.symbol)
                    if symbol is not None]
-    except UnknownMessage:
+    except UnknownMessageError:
         # This can happen due to mismatches of pylint versions and plugin expectations of available messages
         symbols = [message_id_or_symbol]
 

--- a/pylint_plugin_utils/__init__.py
+++ b/pylint_plugin_utils/__init__.py
@@ -1,8 +1,8 @@
 import sys
 try:
-    from pylint.utils import UnknownMessage
+    from pylint.exceptions import UnknownMessageError as UnknownMessage
 except ImportError:
-    from pylint.utils import UnknownMessageError as UnknownMessage
+    from pylint.exceptions import UnknownMessage
 
 
 def get_class(module_name, kls):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email='code@landscape.io',
     description=_short_description,
     version=_version,
-    install_requires=['pylint'],
+    install_requires=['pylint>=1.7'],
     packages=_packages,
     license='GPLv2',
     classifiers=_classifiers,


### PR DESCRIPTION
Also tries to use the newer name (already over three years old) first.

Fixes PyCQA/pylint-plugin-utils#15