### PR TITLE
Fix UnknownMessageError import path

### DIFF
--- a/pylint_plugin_utils/__init__.py
+++ b/pylint_plugin_utils/__init__.py
@@ -2,7 +2,7 @@ import sys
 try:
     from pylint.utils import UnknownMessage
 except ImportError:
-    from pylint.utils import UnknownMessageError as UnknownMessage
+    from pylint.exceptions import UnknownMessageError as UnknownMessage
 
 
 def get_class(module_name, kls):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 from setuptools import find_packages, setup
 
-_version = "0.5"
+_version = "0.6"
 _packages = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 
 _short_description = "Utilities and helpers for writing Pylint plugins"


### PR DESCRIPTION
This PR fixes an issue where I was while running into while trying to run the latest `pylint` (2.4.1) with the latest `pylint-django` (2.0.11):

```
Traceback (most recent call last):
  File "/home/kyle/worktracker/venv/lib/python3.7/site-packages/pylint_plugin_utils/__init__.py", line 3, in <module>
    from pylint.utils import UnknownMessage
ImportError: cannot import name 'UnknownMessage' from 'pylint.utils' (/home/kyle/worktracker/venv/lib/python3.7/site-packages/pylint/utils/__init__.py)
```

I did some digging, and it looks like `UnknownMessageError` has lived in pylint.exceptions since Pylint v1.7: https://github.com/PyCQA/pylint/blob/033201f7216512757dcda1f09ea6d4f7ba9fc2e3/pylint/utils.py#L36. However, this library continued to work because Python allows you to import names that have been imported into a module. Around Pylint 2.4, the utils module was refactored in such a way that it didn't expose `UnknownMessageError , which broke this library.

This PR fixes the import path, and bumps the version from 0.5 to 0.6.